### PR TITLE
Update __init__.py

### DIFF
--- a/commpy/__init__.py
+++ b/commpy/__init__.py
@@ -14,11 +14,11 @@ Subpackages
 
 """
 #from channelcoding import *
-from filters import *
-from modulation import *
-from impairments import *
-from sequences import *
-from channels import *
+from .filters import *
+from .modulation import *
+from .impairments import *
+from .sequences import *
+from .channels import *
 
 try:
     from numpy.testing import Tester


### PR DESCRIPTION
Add dots for import search in the local directory.
This fixes import problems experienced in a jupyter environment for python 3.5