### PR TITLE
Python 3 and modulation.py fixes

### DIFF
--- a/commpy/channelcoding/turbo.py
+++ b/commpy/channelcoding/turbo.py
@@ -87,10 +87,10 @@ def _backward_recursion(trellis, msg_length, noise_variance,
     output_table = trellis.output_table
 
     # Backward recursion
-    for reverse_time_index in reversed(xrange(1, msg_length+1)):
+    for reverse_time_index in reversed(range(1, msg_length+1)):
 
-        for current_state in xrange(number_states):
-            for current_input in xrange(number_inputs):
+        for current_state in range(number_states):
+            for current_input in range(number_inputs):
                 next_state = next_state_table[current_state, current_input]
                 code_symbol = output_table[current_state, current_input]
                 codeword_array = dec2bitarray(code_symbol, n)
@@ -124,11 +124,11 @@ def _forward_recursion_decoding(trellis, mode, msg_length, noise_variance,
     output_table = trellis.output_table
 
     # Forward Recursion
-    for time_index in xrange(1, msg_length+1):
+    for time_index in range(1, msg_length+1):
 
         app[:] = 0
-        for current_state in xrange(number_states):
-            for current_input in xrange(number_inputs):
+        for current_state in range(number_states):
+            for current_input in range(number_inputs):
                 next_state = next_state_table[current_state, current_input]
                 branch_prob = branch_probs[current_input, current_state, time_index-1]
                 # Compute the forward state metrics
@@ -308,7 +308,7 @@ def turbo_decode(sys_symbols, non_sys_symbols_1, non_sys_symbols_2, trellis,
     # Interleave systematic symbols for input to second decoder
     sys_symbols_i = interleaver.interlv(sys_symbols)
 
-    for iteration_count in xrange(number_iterations):
+    for iteration_count in range(number_iterations):
 
         # MAP Decoder - 1
         [L_ext_1, decoded_bits] = map_decode(sys_symbols, non_sys_symbols_1,

--- a/commpy/channels.py
+++ b/commpy/channels.py
@@ -162,7 +162,7 @@ def awgn(input_signal, snr_dB, rate=1.0):
 #    g_var = 0.5
 #    gain_process = zeros([len(path_gains), block_length], dtype=complex)
 #    delay_process = zeros([n2+1-n1, len(path_delays)])
-#    for k in xrange(len(path_gains)):
+#    for k in range(len(path_gains)):
 #        g = (g_var**0.5) * (randn(channel_length) + 1j*randn(channel_length))
 #        g_filt = convolve(g, h_jakes, mode='same')
 #        g_filt_interp = resample(g_filt, block_length)

--- a/commpy/modulation.py
+++ b/commpy/modulation.py
@@ -16,7 +16,8 @@ Modulation Demodulation (:mod:`commpy.modulation`)
 
 """
 from numpy import arange, array, zeros, pi, cos, sin, sqrt, log2, argmin, \
-                  hstack, repeat, tile, dot, sum, shape, concatenate, exp, log
+                  hstack, repeat, tile, dot, sum, shape, concatenate, exp, \
+                  log, vectorize
 from itertools import product
 from commpy.utilities import bitarray2dec, dec2bitarray
 from numpy.fft import fft, ifft
@@ -39,10 +40,10 @@ class Modem:
             Modulated complex symbols.
 
         """
+        mapfunc = vectorize(lambda i:
+            self.constellation[bitarray2dec(input_bits[i:i+self.num_bits_symbol])])
 
-        index_list = map(lambda i: bitarray2dec(input_bits[i:i+self.num_bits_symbol]), \
-                         xrange(0, len(input_bits), self.num_bits_symbol))
-        baseband_symbols = self.constellation[index_list]
+        baseband_symbols = mapfunc(arange(0, len(input_bits), self.num_bits_symbol))
 
         return baseband_symbols
 

--- a/commpy/modulation.py
+++ b/commpy/modulation.py
@@ -113,7 +113,7 @@ class PSKModem(Modem):
         self.m = m
         self.num_bits_symbol = int(log2(self.m))
         self.symbol_mapping = arange(self.m)
-        self.constellation = array(map(self._constellation_symbol,
+        self.constellation = list(map(self._constellation_symbol,
                                  self.symbol_mapping))
 
 class QAMModem(Modem):
@@ -136,7 +136,7 @@ class QAMModem(Modem):
         self.num_bits_symbol = int(log2(self.m))
         self.symbol_mapping = arange(self.m)
         mapping_array = arange(1, sqrt(self.m)+1) - (sqrt(self.m)/2)
-        self.constellation = array(map(self._constellation_symbol,
+        self.constellation = list(map(self._constellation_symbol,
                                  list(product(mapping_array, repeat=2))))
 
 def ofdm_tx(x, nfft, nsc, cp_length):

--- a/commpy/modulation.py
+++ b/commpy/modulation.py
@@ -72,7 +72,7 @@ class Modem:
         """
         if demod_type == 'hard':
             index_list = map(lambda i: argmin(abs(input_symbols[i] - self.constellation)), \
-                             xrange(0, len(input_symbols)))
+                             range(0, len(input_symbols)))
             demod_bits = hstack(map(lambda i: dec2bitarray(i, self.num_bits_symbol),
                                 index_list))
         elif demod_type == 'soft':
@@ -147,7 +147,7 @@ def ofdm_tx(x, nfft, nsc, cp_length):
     cp_length = float(cp_length)
     ofdm_tx_signal = array([])
 
-    for i in xrange(0, shape(x)[1]):
+    for i in range(0, shape(x)[1]):
         symbols = x[:,i]
         ofdm_sym_freq = zeros(nfft, dtype=complex)
         ofdm_sym_freq[1:(nsc/2)+1] = symbols[nsc/2:]
@@ -164,7 +164,7 @@ def ofdm_rx(y, nfft, nsc, cp_length):
     num_ofdm_symbols = int(len(y)/(nfft + cp_length))
     x_hat = zeros([nsc, num_ofdm_symbols], dtype=complex)
 
-    for i in xrange(0, num_ofdm_symbols):
+    for i in range(0, num_ofdm_symbols):
         ofdm_symbol = y[i*nfft + (i+1)*cp_length:(i+1)*(nfft + cp_length)]
         symbols_freq = fft(ofdm_symbol)
         x_hat[:,i] = concatenate((symbols_freq[-nsc/2:], symbols_freq[1:(nsc/2)+1]))

--- a/commpy/sequences.py
+++ b/commpy/sequences.py
@@ -49,11 +49,11 @@ def pnsequence(pn_order, pn_seed, pn_mask, seq_length):
     pnseq = zeros(seq_length)
 
     # Initialize shift register with the pn_seed
-    sr = array(map(lambda i: int(pn_seed[i]), xrange(0, len(pn_seed))))
+    sr = array(map(lambda i: int(pn_seed[i]), range(0, len(pn_seed))))
 
-    for i in xrange(seq_length):
+    for i in range(seq_length):
         new_bit = 0
-        for j in xrange(pn_order):
+        for j in range(pn_order):
             if int(pn_mask[j]) == 1:
                 new_bit = new_bit ^ sr[j]
         pnseq[i] = sr[pn_order-1]

--- a/doc/sphinxext/plot_directive.py
+++ b/doc/sphinxext/plot_directive.py
@@ -520,7 +520,7 @@ def makefig(code, code_path, output_dir, output_base, config):
     all_exists = True
     for i, code_piece in enumerate(code_pieces):
         images = []
-        for j in xrange(1000):
+        for j in range(1000):
             img = ImageFile('%s_%02d_%02d' % (output_base, i, j), output_dir)
             for format, dpi in formats:
                 if out_of_date(code_path, img.filename(format)):


### PR DESCRIPTION
Replaced all the remaining xrange()s with range()s

Fixed up the modulate and __init__ methods in the Modem class and subclasses to work with Python 3 and newer numpys.

Tests good with Python 2.7.13 and Python 3.5.3, and with numpy 1.13.1.