### PR TITLE
Fix type checking for `Complex` ndarray

### DIFF
--- a/commpy/channels.py
+++ b/commpy/channels.py
@@ -94,7 +94,7 @@ def awgn(input_signal, snr_dB, rate=1.0):
     snr_linear = 10**(snr_dB/10.0)
     noise_variance = avg_energy/(2*rate*snr_linear)
 
-    if type(input_signal[0]) == complex:
+    if isinstance(input_signal[0], complex):
         noise = (sqrt(noise_variance) * randn(len(input_signal))) + (sqrt(noise_variance) * randn(len(input_signal))*1j)
     else:
         noise = sqrt(2*noise_variance) * randn(len(input_signal))


### PR DESCRIPTION
This pull request updates type-checking for Complex ndarray in `commpy.channels.awgn` method.  Discussed in https://github.com/veeresht/CommPy/issues/19