### PR TITLE
Update method visualize()

### DIFF
--- a/commpy/channelcoding/convcode.py
+++ b/commpy/channelcoding/convcode.py
@@ -257,7 +257,7 @@ class Trellis:
             edge_colors = ["#9E1BE0", "#06D65D"]
 
         if state_order is None:
-            state_order = range(self.number_states)
+            state_order = list(range(self.number_states))
 
         font = "sans-serif"
         fig = plt.figure()


### PR DESCRIPTION
Add-on for Python 3 compatibility. In Python 3, the range() method returns a range data type that, for example, does not have a reverse () method.