### PR TITLE
Bug fix in trellis generation

### DIFF
--- a/commpy/channelcoding/convcode.py
+++ b/commpy/channelcoding/convcode.py
@@ -122,8 +122,12 @@ class Trellis:
                         # Loop over M delay elements of the shift register
                         # to compute their contribution to the r-th output
                         for i in range(memory[l]):
-                            outbits[r] = (outbits[r] + \
+                            if l == 0:
+                                outbits[r] = (outbits[r] + \
                                 (shift_register[i+l]*generator_array[i+1])) % 2
+                            else:
+                                outbits[r] = (outbits[r] + \
+                                (shift_register[i+memory[l-1]+l-1]*generator_array[i+1])) % 2
 
                         output_generator_array[l] = generator_array[0]
                         if l == 0:

--- a/commpy/channelcoding/convcode.py
+++ b/commpy/channelcoding/convcode.py
@@ -316,7 +316,10 @@ def conv_encode(message_bits, trellis, termination = 'term', puncture_matrix=Non
             number_outbits = int(number_inbits/rate)
 
     outbits = np.zeros(number_outbits, 'int')
-    p_outbits = np.zeros(int(number_outbits*
+    if puncture_matrix is not None:
+        p_outbits = np.zeros(number_outbits)
+    else:
+        p_outbits = np.zeros(int(number_outbits*
             puncture_matrix[0:].sum()/np.size(puncture_matrix, 1)), 'int')
     next_state_table = trellis.next_state_table
     output_table = trellis.output_table


### PR DESCRIPTION
 Argument "memory" in poly2trellis indicates length of shift register(SR) that used for convolution encoder and total number of SR's is equal to number of inputs to convolution encoder.

In present code, only first SR is used for all inputs and the bits stored in remaining SR's is not utilised causing convolution encoder producing a sequence not same as in [1].

Modified code such that bits stored in all the SR's are used for generating output sequence(line number 125 to 130). This produces output compatible with [1].

Tested with 1/2 and 2/3 encoding rates.

[1] Todd K. Moon. Error Correction Coding: Mathematical Methods and
        Algorithms. John Wiley and Sons, 2005