### PR TITLE
[minor] Update Thanks file & Python 2 compatibility

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -2,7 +2,7 @@ Please add names as needed so that we can keep up with all the contributors.
 
 Veeresh Taranalli for initial creation and contribution of CommPy.
 Bastien Trotobas for adding some features, bugfixes, maintenance.
-Vladimir Fadeev for bugfixes, addition of convolutional code puncturing.
+Vladimir Fadeev for bugfixes, addition of convolutional code puncturing and readme explanation of codings.
 Youness Akourim for adding features and fixing some bugs.
 Rey Tucker for python3 compatibility fixes.
 Dat Nguyen for type check fix for AWGN channel model.

--- a/commpy/examples/conv_encode_decode.py
+++ b/commpy/examples/conv_encode_decode.py
@@ -1,6 +1,8 @@
 # Authors: CommPy contributors
 # License: BSD 3-Clause
 
+from __future__ import division, print_function  # Python 2 compatibility
+
 import math
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
I missed a Python 2 compatibility issue in the previous PR.

Do we agree to drop Python 2 compatibility since it will [retire in a few months](https://pythonclock.org/)? If so, one just have to change update the main readme with the right requirements.