### PR TITLE
Galois Field minor improvements.

### DIFF
--- a/commpy/channelcoding/gfields.py
+++ b/commpy/channelcoding/gfields.py
@@ -5,7 +5,7 @@
 
 from fractions import gcd
 
-from numpy import array, zeros, arange, convolve, ndarray, concatenate, empty
+from numpy import array, zeros, arange, convolve, ndarray, concatenate, empty, where
 
 from commpy.utilities import dec2bitarray, bitarray2dec
 
@@ -131,8 +131,8 @@ class GF:
         for idx, i in enumerate(self.elements):
             if i == -1:
                 y[idx] = 0
-            #  elif i < self.m:
-                #  y[idx] = 2**i
+            elif i < self.m:
+                y[idx] = int(2**i)
             else:
                 y[idx] = polydivide(2**i, self.prim_poly)
         return GF(y, self.m)
@@ -173,6 +173,7 @@ class GF:
         """
         coset_list = []
         x = self.tuple_to_power().elements
+        x = where(x == -1, 0, x)
         mark_list = zeros(len(x))
         coset_count = 1
         for idx in range(len(x)):
@@ -188,7 +189,7 @@ class GF:
                 coset_count+=1
 
         for counts in range(1, coset_count):
-            coset_list.append(GF(self.elements[mark_list==counts], self.m))
+            coset_list.append(GF(self.elements[mark_list==counts], self.m, repr_form = "power"))
 
         return coset_list
 

--- a/commpy/channelcoding/gfields.py
+++ b/commpy/channelcoding/gfields.py
@@ -62,7 +62,7 @@ class GF:
         self.repr_form = repr_form
         self.m = m
         primpoly_array = array([0, 3, 7, 11, 19, 37, 67, 137, 285, 529, 1033,
-                                   2053, 4179, 8219, 17475, 32771, 69643])
+                                2053, 4179, 8219, 17475, 32771, 69643])
         self.prim_poly = primpoly_array[self.m]
 
         if type(x) is int:
@@ -78,7 +78,7 @@ class GF:
                 raise AssertionError("GF input not in a supported form.")
         elif type(x) is ndarray and len(x) >= 1:
             if self.input_form == "power":
-                self.elements = array([e % int((pow(2, self.m)) - 1) if e!=-1 else -1 for e in x]).astype(int)
+                self.elements = array([e % int((pow(2, self.m)) - 1) if e != -1 else -1 for e in x]).astype(int)
                 self.elements = self.power_to_tuple().elements.astype(int)
             elif self.input_form == "tuple":
                 self.elements = x.astype(int)
@@ -107,7 +107,7 @@ class GF:
                     prod_elements[i] = (a[i] + b[i]) % (pow(2, self.m) - 1)
             return GF(prod_elements, self.m, input_form="power", repr_form=self.repr_form)
         else:
-             raise ValueError("Two sets of elements cannot be multiplied")
+            raise ValueError("Two sets of elements cannot be multiplied")
 
     # Overloading equality operator for Galois Field
     def __eq__(self, other):
@@ -119,9 +119,9 @@ class GF:
     # String representation for class
     def __repr__(self):
         if self.repr_form == "tuple":
-            return f"Tuple representation for elements in GF(2^{self.m}): {self.elements}"
+            return "Tuple representation for elements in GF(2^{}): {}".format(self.m, self.elements)
         elif self.repr_form == "power":
-            return f"Power representation for elements in GF(2^{self.m}): {self.tuple_to_power().elements.astype(int)}"
+            return "Power representation for elements in GF(2^{}): {}".format(self.m, self.tuple_to_power().elements.astype(int))
 
     def power_to_tuple(self):
         """

--- a/commpy/channelcoding/tests/test_gfields.py
+++ b/commpy/channelcoding/tests/test_gfields.py
@@ -15,7 +15,7 @@ class TestGaloisFields(object):
             for a in x.elements:
                 for b in x.elements:
                     assert_((GF(array([a]), m) + GF(array([b]), m)).elements[0] in x.elements)
-                    assert_((GF(array([a]), m) * GF(array([b]), m)).elements[0] in x.elements)
+                    assert_((GF(array([a]), m, input_form="power") * GF(array([b]), m, input_form="power")).elements[0] in x.elements)
 
     def test_addition(self):
         m = 3
@@ -66,3 +66,24 @@ class TestGaloisFields(object):
         x = GF(array([2, 8, 32, 6, 24, 35, 10, 40, 59, 41, 14, 37]), m)
         z = array([67, 87, 103, 73, 13, 109, 91, 117, 7, 115, 11, 97])
         assert_array_equal(x.minpolys(), z)
+
+    def test_power_form_input(self):
+        m = 3
+        y = GF(arange(2**m - 1), m, input_form="power")
+        z = GF(array([1, 2, 4, 3, 6, 7, 5]), m)
+        assert_array_equal(y, z)
+
+        m = 4
+        y = GF(arange(2**m - 1), m, input_form="power")
+        z = GF(array([1, 2, 4, 8, 3, 6, 12, 11, 5, 10, 7, 14, 15, 13, 9]), m)
+        assert_array_equal(y, z)
+
+    def test_power_mult(self):
+        m = 3
+        x = GF(array([0, 1, 2, 5]), m, input_form="power", repr_form="power")
+        y = GF(array([3, 2, 0, 1]), m, input_form="power", repr_form="power")
+        z = x * y
+        e = GF(array([3, 3, 2, 6]), m, input_form="power", repr_form="power")
+        assert_array_equal(z, e)
+
+


### PR DESCRIPTION
Hello, thanks for the development of this project.

I was thinking about implementing some linear block codes that I think should be a good addition for the project: Hamming, BCH, ReedSolomon, Reed-Muller, SoftDecision techniques for algebraic codes.

I started looking for the current GaloisField implementation and I initially didn't quite understand the input form for the elements since most projects represent Galois elements by it power form (element alpha^5 in GF(8) is represented by integer "5"), which should have more than one benefit for this kind of representation in terms of performance and usability. For instance, the __mul__ operation can be done simple as a sum mod (2^m - 1) in power form.

I'm opening a draft pull request to discuss following points:

- User can input GF elements as power form elements. This facilitates __mul__ operation and complicate the addition (should convert elements to tuple form before addition).
- As things currently are in this draft pull request the GF class is still representing the elements internally in tuple form. In the test case for closure this still can represent a slight speed performance boost even though I'm converting power(user input)->tuple(__init__ method)->power(__mul__ method).
- Maybe we should represent elements internally in power form only, or at least give the user the option to directly input elements in this form without needing to declare a GF class just to use the power_to_tuple method, extract the elements and declare another GF class.
- Some minor additions like __eq__ and __repr__ should also be handy.

Looking forward to discuss possible changes to the GF class and your opinion on the possible addition of more linear block codes and techniques.
