### PR TITLE
Fixed Attribute Error on running commpy/examples/conv_encode_decode.py

### DIFF
--- a/commpy/examples/conv_encode_decode.py
+++ b/commpy/examples/conv_encode_decode.py
@@ -137,8 +137,8 @@ model_soft = lk.LinkModel(modulate, channels, receiver_soft,
                           decoder_soft, code_rate)
 
 # Test
-BERs_hard = model_hard.link_performance(SNRs, 10000, 600, 5000, code_rate)
-BERs_soft = model_soft.link_performance(SNRs, 10000, 600, 5000, code_rate)
+BERs_hard = lk.link_performance(model_hard, SNRs, 10000, 600, 5000, code_rate)
+BERs_soft = lk.link_performance(model_soft, SNRs, 10000, 600, 5000, code_rate)
 plt.semilogy(SNRs, BERs_hard, 'o-', SNRs, BERs_soft, 'o-')
 plt.grid()
 plt.xlabel('Signal to Noise Ration (dB)')


### PR DESCRIPTION
Hey,

While trying to run the example conv_encode_decode.py, I got this error:

```
Traceback (most recent call last):  
  File "commpy/examples/conv_encode_decode.py", line 140, in <module>
    BERs_hard = model_hard.link_performance(SNRs, 10000, 600, 5000, code_rate)
AttributeError: 'LinkModel' object has no attribute 'link_performance'
```

I changed the line (and the next, with `model_soft`) to:
`BERs_hard = lk.link_performance(model_hard, SNRs, 10000, 600, 5000, code_rate)`  
`BERs_soft = lk.link_performance(model_soft, SNRs, 10000, 600, 5000, code_rate)`

Now I don't get the error I mentioned. Please incorporate this change.