### PR TITLE
Speed improvements

### DIFF
--- a/commpy/channelcoding/convcode.py
+++ b/commpy/channelcoding/convcode.py
@@ -561,12 +561,13 @@ def conv_encode(message_bits, trellis, termination = 'term', puncture_matrix=Non
 def _where_c(inarray, rows, cols, search_value, index_array):
 
     number_found = 0
-    for i in range(rows):
-        for j in range(cols):
-            if inarray[i, j] == search_value:
-                index_array[number_found, 0] = i
-                index_array[number_found, 1] = j
-                number_found += 1
+    res = np.where(inarray == search_value)
+    i_s, j_s = res
+    for i, j in zip(i_s, j_s):
+        if inarray[i, j] == search_value:
+            index_array[number_found, 0] = i
+            index_array[number_found, 1] = j
+            number_found += 1
 
     return number_found
 

--- a/commpy/channelcoding/convcode.py
+++ b/commpy/channelcoding/convcode.py
@@ -5,6 +5,7 @@
 
 from __future__ import division
 
+import functools
 import math
 from warnings import warn
 
@@ -570,6 +571,19 @@ def _where_c(inarray, rows, cols, search_value, index_array):
     return number_found
 
 
+@functools.lru_cache(maxsize=128, typed=False)
+def _compute_branch_metrics(decoding_type, r_codeword, i_codeword_array):
+    if decoding_type == 'hard':
+        return hamming_dist(r_codeword.astype(int), i_codeword_array.astype(int))
+    elif decoding_type == 'soft':
+        neg_LL_0 = np.log(np.exp(r_codeword) + 1)  # negative log-likelihood to have received a 0
+        neg_LL_1 = neg_LL_0 - r_codeword  # negative log-likelihood to have received a 1
+        return np.where(i_codeword_array, neg_LL_1, neg_LL_0).sum()
+    elif decoding_type == 'unquantized':
+        i_codeword_array = 2 * i_codeword_array - 1
+        return euclid_dist(r_codeword, i_codeword_array)
+
+
 def _acs_traceback(r_codeword, trellis, decoding_type,
                    path_metrics, paths, decoded_symbols,
                    decoded_bits, tb_count, t, count,
@@ -605,15 +619,7 @@ def _acs_traceback(r_codeword, trellis, decoding_type,
             i_codeword_array = dec2bitarray(i_codeword, n)
 
             # Compute Branch Metrics
-            if decoding_type == 'hard':
-                branch_metric = hamming_dist(r_codeword.astype(int), i_codeword_array.astype(int))
-            elif decoding_type == 'soft':
-                neg_LL_0 = np.log(np.exp(r_codeword) + 1)  # negative log-likelihood to have received a 0
-                neg_LL_1 = neg_LL_0 - r_codeword  # negative log-likelihood to have received a 1
-                branch_metric = np.where(i_codeword_array, neg_LL_1, neg_LL_0).sum()
-            elif decoding_type == 'unquantized':
-                i_codeword_array = 2*i_codeword_array - 1
-                branch_metric = euclid_dist(r_codeword, i_codeword_array)
+            branch_metric = _compute_branch_metrics(decoding_type, tuple(r_codeword), tuple(i_codeword_array))
 
             # ADD operation: Add the branch metric to the
             # accumulated path metric and store it in the temporary array

--- a/commpy/links.py
+++ b/commpy/links.py
@@ -203,7 +203,7 @@ class LinkModel:
                 # Deals with MIMO channel
                 if isinstance(self.channel, MIMOFlatChannel):
                     nb_symb_vector = len(channel_output)
-                    received_msg = np.empty(int(math.ceil(len(msg) / self.rate)))
+                    received_msg = np.empty(int(math.ceil(len(msg) / self.rate)), dtype=np.int8)
                     for i in range(nb_symb_vector):
                         received_msg[receive_size * i:receive_size * (i + 1)] = \
                             self.receive(channel_output[i], self.channel.channel_gains[i],

--- a/commpy/links.py
+++ b/commpy/links.py
@@ -216,9 +216,9 @@ class LinkModel:
                     decoded_bits = self.decoder(channel_output, self.channel.channel_gains,
                                                 self.constellation, self.channel.noise_std ** 2,
                                                 received_msg, self.channel.nb_tx * self.num_bits_symbol)
-                    bit_err += (msg != decoded_bits[:len(msg)]).sum()
+                    bit_err += np.bitwise_xor(msg, decoded_bits[:len(msg)]).sum()
                 else:
-                    bit_err += (msg != self.decoder(received_msg)[:len(msg)]).sum()
+                    bit_err += np.bitwise_xor(msg, self.decoder(received_msg)[:len(msg)]).sum()
                 bit_send += send_chunk
             BERs[id_SNR] = bit_err / bit_send
             if bit_err < err_min:

--- a/commpy/utilities.py
+++ b/commpy/utilities.py
@@ -17,6 +17,7 @@ Utilities (:mod:`commpy.utilities`)
    upsample             -- Upsample by an integral factor (zero insertion).
    signal_power         -- Compute the power of a discrete time signal.
 """
+import functools
 
 import numpy as np
 
@@ -47,13 +48,14 @@ def dec2bitarray(in_number, bit_width):
     """
 
     if isinstance(in_number, (np.integer, int)):
-        return decimal2bitarray(in_number, bit_width)
+        return decimal2bitarray(in_number, bit_width).copy()
     result = np.zeros(bit_width * len(in_number), np.int8)
     for pox, number in enumerate(in_number):
-        result[pox * bit_width:(pox + 1) * bit_width] = decimal2bitarray(number, bit_width)
+        result[pox * bit_width:(pox + 1) * bit_width] = decimal2bitarray(number, bit_width).copy()
     return result
 
 
+@functools.lru_cache(maxsize=128, typed=False)
 def decimal2bitarray(number, bit_width):
     """
     Converts a positive integer to NumPy array of the specified size containing bits (0 and 1). This version is slightly


### PR DESCRIPTION
Hello, 

In the past few weeks I have been using the library for some heavy number of runs and notice some bottlenecks.
Here are some contributions to patch some of the bottlenecks found to try to make the simulation faster.
 - Added caching using an LRU cache in some functions that are slow and repeatedly called with same parameters;
 - Change not-equal comparison of numpy arrays to bitwise xor since they are 1's and 0's;
 - Reduce iterations in the _where_c function by taking advantage of numpy function to search for a value; 

Between each commit the following test was performed (based on conv_encode_decode):
```python
# Authors: CommPy contributors
# License: BSD 3-Clause

import math
import time
from datetime import timedelta

import numpy as np

import commpy.channelcoding.convcode as cc
import commpy.channels as chan
import commpy.links as lk
import commpy.modulation as mod

# =============================================================================
# Convolutional Code 1: G(D) = [1+D^2, 1+D+D^2]
# Standard code with rate 1/2
# =============================================================================

# Number of delay elements in the convolutional encoder
memory = np.array(6, ndmin=1)

# Generator matrix
g_matrix = np.array((0o5, 0o7), ndmin=2)

# Create trellis data structure
trellis1 = cc.Trellis(memory, g_matrix)

# ==================================================================================================
# Complete example using Commpy features and compare hard and soft demodulation. Example with code 1
# ==================================================================================================

# Modem : QPSK
modem = mod.QAMModem(4)

# AWGN channel
channels = chan.SISOFlatChannel(None, (1 + 0j, 0j))

# SNR range to test
SNRs = np.arange(0, 6) + 10 * math.log10(modem.num_bits_symbol)


# Modulation function
def modulate(bits):
    return modem.modulate(cc.conv_encode(bits, trellis1, 'cont'))


# Receiver function (no process required as there are no fading)
def receiver_soft(y, h, constellation, noise_var):
    return modem.demodulate(y, 'soft', noise_var)


# Decoder function
def decoder_soft(msg):
    return cc.viterbi_decode(msg, trellis1, decoding_type='soft')


# Build model from parameters
code_rate = trellis1.k / trellis1.n
model_soft = lk.LinkModel(modulate, channels, receiver_soft,
                          modem.num_bits_symbol, modem.constellation, modem.Es,
                          decoder_soft, code_rate)

# Test
start = time.time()
BERs_soft = model_soft.link_performance(SNRs, 1000, 600, 5000, code_rate)
print(str(timedelta(seconds=(time.time() - start))))
```


Rough results for each commit are presented bellow:

> base (the repo at master) - 0:00:42.092337
> with added cache (commit fc764d5cb21e4c87a9e57cbf183ce06950a1aa6b) - 0:00:33.801127
> with bitwise xor improvement (commit a9d3aa7958798d52e814145af6290e611fbc8eca) - 0:00:31.678570
> improvement where_c (commit c276ede9e91e7bba55ae3edf28742e7c827ec0e2) - 0:00:13.405827