### PR TITLE
Remove slow flag in Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
     - python setup.py install
 script:
     # Your test script goes here
-    - nosetests -a '!slow' --with-coverage --cover-package=commpy --logging-level=INFO
+    - nosetests --with-coverage --cover-package=commpy --logging-level=INFO
 # Calculate coverage
 after_success:
     - coveralls


### PR DESCRIPTION
The flag `-a 'slow'` in the Travis configuration file creates two issues:

- some bugs are not detected by Travis during commits and PRs. See for example #76 
- the coverage report is inconsistant since some functions are covered but the corresponding test is not executed. This has been already noted in #55 and some further experiments confirm this assumption.

Removing this flag would leads to a much longer computation time on Travis. I'm not aware of any limitation from Travis on the amount of computation that can be executed. Moreover, imo it is safer to have a reliable test that take a long time to execute rather than an inconsistant short one.

If the computation time is really an issue, we could split the tests in two command lines. The first command execute only the short tests and provides a quick answer then the other tests are run afterwards. If you prefer this option, feel free to push on my branch or to merge the PR and do the changes.