### PR TITLE
Fix wrong modulation for mcs 1 and 2

### DIFF
--- a/commpy/tests/test_wifi80211.py
+++ b/commpy/tests/test_wifi80211.py
@@ -17,7 +17,7 @@ def test_wifi80211_siso_channel():
     seed(17121996)
     wifi80211 = Wifi80211(1)
     BERs = wifi80211.link_performance(SISOFlatChannel(fading_param=(1 + 0j, 0)), range(0, 9, 2), 10 ** 4, 600)[0]
-    desired = (0.489, 0.503, 0.446, 0.31, 0.015)  # From previous tests
+    desired = (0.548, 0.508, 0.59, 0.81, 0.18)  # From previous tests
     # for i, val in enumerate(desired):
     #     print((BERs[i] - val) / val)
     assert_allclose(BERs, desired, rtol=0.3,

--- a/commpy/wifi80211.py
+++ b/commpy/wifi80211.py
@@ -52,7 +52,7 @@ class Wifi80211:
         """
         Gets the modem that is going to be used for this particular WiFi simulation according to the MCS
         """
-        qpsks = [
+        bits_per_symbol = [
             2,
             4,
             4,
@@ -63,12 +63,13 @@ class Wifi80211:
             256,
             256
         ]
-        if self.mcs == 0:
-            # BPSK
-            return mod.PSKModem(2)
+        if self.mcs <= 2:
+            # BPSK for mcs 0
+            # QPSK for mcs 1 a 2
+            return mod.PSKModem(bits_per_symbol[self.mcs])
         else:
-            # Modem : QPSK
-            return mod.QAMModem(qpsks[self.mcs])
+            # Modem : QAMModem
+            return mod.QAMModem(bits_per_symbol[self.mcs])
 
     @staticmethod
     def _get_puncture_matrix(numerator: int, denominator: int) -> List:


### PR DESCRIPTION
QPSK is used for MCS 1 and 2, was using QAM by mistake.