### PR TITLE
Package_data files list fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ VERSION = '0.7.0'
 #This is a list of files to install, and where
 #(relative to the 'root' dir, where setup.py is)
 #You could be more specific.
-files = ["channelcoding/*, channelcoding/tests/*, tests/*, channelcoding/designs/ldpc/gallager/*, channelcoding/designs/ldpc/wimax/*"]
+files = ["channelcoding/*", "channelcoding/tests/*", "tests/*", "channelcoding/designs/ldpc/gallager/*", "channelcoding/designs/ldpc/wimax/*"]
 
 setup(
     name=DISTNAME,


### PR DESCRIPTION
I noticed that the design text files for gallager and wimax were not being installed even though they are listed in the package_data. I separated the string of directories for the files list so that each individual directory is added including the txt files in gallager/wimax.