### PR TITLE
Fixed installation error on Chinese version of Windows 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 # Taken from scikit-learn setup.py
 DISTNAME = 'scikit-commpy'
 DESCRIPTION = 'Digital Communication Algorithms with Python'
-LONG_DESCRIPTION = open('README.md').read()
+LONG_DESCRIPTION = open('README.md', encoding='utf-8').read()
 MAINTAINER = 'Veeresh Taranalli & Bastien Trotobas'
 MAINTAINER_EMAIL = 'veeresht@gmail.com'
 URL = 'http://veeresht.github.com/CommPy'


### PR DESCRIPTION
When I installed CommPy on Chinese version of Windows 10, I came across an error: "
File "C:\Users\songlei-cn\AppData\Local\Temp\pip-install-77v4aupp\scikit-commpy_e4831557bdbb40d5b50ec608ac738943\setup.py", line 9, in <module>
LONG_DESCRIPTION = open('README.md').read()
UnicodeDecodeError: 'gbk' codec can't decode byte 0x9d in position 5282: illegal multibyte sequence".
It seems that the default encoding for Chinese version of Windows 10 is 'gbk' instead of 'utf-8'.
It is necessary to explicitly declare the open function using UTF-8 encoding.