### PR TITLE
Quick fix in setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 # Taken from scikit-learn setup.py
 DISTNAME = 'scikit-commpy'
 DESCRIPTION = 'Digital Communication Algorithms with Python'
-LONG_DESCRIPTION = open('README.md').read()
+LONG_DESCRIPTION = open('README.md', encoding="utf8").read()
 MAINTAINER = 'Veeresh Taranalli & Bastien Trotobas'
 MAINTAINER_EMAIL = 'veeresht@gmail.com'
 URL = 'http://veeresht.github.com/CommPy'


### PR DESCRIPTION
Hi guys, there is an issue preventing the installation of CommPy 0.7.0 via PIP in Windows. When attempting to do `pip install scikit-commpy` on Windows, version 0.6.0 is installed instead, due to a bug in setup.py in version 0.7.0. I don't know if the same issue appears in other OS.  Looking at the error logs and similar issues reported on StackOverflow, I found a quick fix.

In setup.py, change:
```
LONG_DESCRIPTION = open('README.md').read()
```
to

```
LONG_DESCRIPTION = open('README.md', encoding="utf8").read()
```

That should fix the pip installation on Windows. I tested it and this fix allowed me to install version 0.7.0 on my Windows PC.